### PR TITLE
Fix #4: Update requirements to websockets 7.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ ongoing battle.
 
 ### Requirements
 - Python 3.5 or newer
-- [websockets 3.3](https://github.com/aaugustin/websockets) (`pip3 install websockets==3.3`)
+- [websockets 7.0](https://github.com/aaugustin/websockets) (`pip3 install websockets==7.0`)
 
 ## Server
 ### Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-websockets==3.3
+websockets==7.0

--- a/start.py
+++ b/start.py
@@ -3,7 +3,7 @@ Startup script for the pyTanks server
 
 Requirements:
     Python 3.5 or newer
-    websockets 3.3 (pip install websockets==3.3)
+    websockets 7.0 (pip install websockets==7.0)
 
 Usage:
     python start.py


### PR DESCRIPTION
Fixes `websockets` build errors by updating required version to 7.0.

I just picked the newest version and didn't check to see which exact version started building successfully. Feel free to lower requirement.

Also feel free to double-check that source changes aren't necessary. I don't have an extensive Python environment on my machine.