### PR TITLE
Allow minPlayers=n on command line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,10 @@ ongoing battle.
 The pyTanks player uses the settings found in `config.py` to control how the client works. Those values 
 can be changed directly or be overridden by appending one or more of these command line args:
 - `log=n` - Overrides the default logging level.
+- `minPlayers=n` - Overrides the minimum number of players required to start a game.
 - `ip:port` - Overrides the ip and port used to host the server.
 
-Where the log level is one of:
+The log level must be one of:
 - 0 for no logging
 - 1 for connect/disconnect and new game
 - 2 for server status and client errors
@@ -34,6 +35,8 @@ Where the log level is one of:
 - 5 for verbose websocket logs
 
 (All log events of a log level equal to or less than the set log level will be printed.)
+
+The minimum player count must be at least 2. Setting this override is useful during development when you want to test the performance of your tank against one other player. For example, setting minPlayers=2 will start a new round as soon as your tank dies.
 
 ### Project structure
 The pyTanks server is built around ansycio tasks with a main game logic task, an incoming messages task 

--- a/start.py
+++ b/start.py
@@ -52,7 +52,7 @@ def main():
                 if num <= 1:
                     print("minPlayers must be greater than 1")
                     return
-                config.server.minPlayers = int(arg[-1:])
+                config.server.minPlayers = num
             except ValueError:
                 print("Invalid min player count")
                 return

--- a/start.py
+++ b/start.py
@@ -46,6 +46,16 @@ def main():
             except ValueError:
                 print("Invalid log level")
                 return
+        elif arg.startswith("minPlayers="):
+            try:
+                num = int(arg[-1:])
+                if num <= 1:
+                    print("minPlayers must be greater than 1")
+                    return
+                config.server.minPlayers = int(arg[-1:])
+            except ValueError:
+                print("Invalid min player count")
+                return
         elif ":" in arg:
             config.server.ipAndPort = arg
         else:


### PR DESCRIPTION
Setting `minPlayers=n` on the command line will override the default value of 4 players to start a game. This will enable player developers to easily test their tanks against a single opponent and have a new game start when it is killed (via `minPlayers=2`).